### PR TITLE
Add DOI code basic validation

### DIFF
--- a/resolver.html
+++ b/resolver.html
@@ -11,7 +11,7 @@
     <b>DOI</b><br/>
     <input type="text" id="DOI" name="DOI" size="40"></textarea>
     <button type="button" id="resolveDOI" onclick="resolveDOI()">Resolve DOI</button><br/>
-    <span class="note" id="doierrormessage"></span>
+    <span class="note" id="doierrormessage" style="font-weight: bold"></span>
     <div id="openaccessdiv" style="display:none">
       <br/>
       <button type="button" id="openaccessbutton">View Open Access Version</button><br/>


### PR DESCRIPTION
**WHY:**
The current value processing doesn't do a sanity check for the DOI code. It is possible to enter some garbage in the field and it will try to make a call to doi.org using the garbage as the URL path.

The proposed change introduce a very basic sanity check for the DOI code, coming from the observation that the valid code should start from a group of at least three digits, possibly with periods and dashes as separators.

**WHAT:**
- Strip the URL prefix from the entered value (if any) and do a sanity check for a result as a DOI code prior to call doi.org;
- Repurpose `displayErrorMessage()` function to display a given error message instead of the predefined one.
